### PR TITLE
Fix build error on Windows

### DIFF
--- a/options_examples/options_conda_win.py
+++ b/options_examples/options_conda_win.py
@@ -3,6 +3,6 @@
 
 compiler = 'msvc'
 qhull_libs_suffix = 'static'
-
+boost_libs_suffix = ''
 #EXTRA_LINKFLAGS ='/NODEFAULTLIB:boost_python-vc140-mt-1_65_1'
 #EXTRA_LINKFLAGS +=' /MACHINE:'+('X86' if  sys.maxsize.bit_length() < 63 else 'X64')


### PR DESCRIPTION
Remove boost suffix on windows.
The boost lib is boost_python.lib rather than boost_python-vc9.lib